### PR TITLE
checkAuth's verifiedToken was giving a fucking ts error of string|end…

### DIFF
--- a/src/middlewares/checkAuth.ts
+++ b/src/middlewares/checkAuth.ts
@@ -29,7 +29,7 @@ export const checkAuth =
 
       const verifiedToken = verifyToken(
         accessToken,
-        process.env.JWT_ACCESS_SECRET
+        process.env.JWT_ACCESS_SECRET as string
       ) as JwtPayload;
       if (!verifiedToken) {
         throw new AppError(404, "Could not found verifiedTOken");


### PR DESCRIPTION
fixed chekAuth's verified token's 


before:
```
const verifiedToken = verifyToken(
        accessToken,
        process.env.JWT_ACCESS_SECRET
      ) as JwtPayload;
      if (!verifiedToken) {
        throw new AppError(404, "Could not found verifiedTOken");
      }
```
after
```
const verifiedToken = verifyToken(
        accessToken,
        process.env.JWT_ACCESS_SECRET as string
      ) as JwtPayload;
      if (!verifiedToken) {
        throw new AppError(404, "Could not found verifiedTOken");
      }
```